### PR TITLE
MAINT: Automate versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_version.py
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "wbhiutils"
-version = "1.0.2"
+dynamic = ["version"]
+
+[tool.hatch.version]
+source = "vcs"


### PR DESCRIPTION
Updates required manually tagging the new version to see effect - this adds automatic vcs versioning so we don't have to deal with it